### PR TITLE
Pull the changes from next-release to main. (#103)

### DIFF
--- a/VS2022/How To Run a Local Lobby and Server.txt
+++ b/VS2022/How To Run a Local Lobby and Server.txt
@@ -10,4 +10,4 @@ Go to C:\Allegiance\Server
 Follow instructions in the readme. 
 
     
-The batch files are looking for files in these paths, so it would be easiest not to modify them.
+The batch files are looking for files in these paths, so it would be easiest not to modify them...

--- a/VS2022/Shared.props
+++ b/VS2022/Shared.props
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalIncludeDirectories>..\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>__MODULE__="$(ProjectName)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup />
+</Project>

--- a/src/Igc/common.cpp
+++ b/src/Igc/common.cpp
@@ -2357,7 +2357,7 @@ bool        LineOfSightExist(const IclusterIGC* pcluster,
             Vector          V13 = P3 - P1;
             float           fLengthSquaredV13 = V13.LengthSquared ();
 
-            // if the obscruing object is closer than the target, then it might really
+            // if the obscuring object is closer than the target, then it might really
             // obscure the view of the target
             if (fLengthSquaredV13 < fLengthSquaredV12)
             {

--- a/src/Igc/igc.h
+++ b/src/Igc/igc.h
@@ -1252,7 +1252,7 @@ public:
         bLockLobby                      = false;
         bLockSides                      = false;
         bLockTeamSettings               = false;
-        bAllowDefections                = false;
+        bAllowDefections                = false; //Student TODO
         bStations                       = true ;
         bScoresCount                    = true;
         bSquadGame                      = false;

--- a/src/Igc/shipIGC.cpp
+++ b/src/Igc/shipIGC.cpp
@@ -1218,6 +1218,7 @@ DamageResult CshipIGC::ReceiveDamage(DamageTypeID            type,
 {
     IsideIGC*   pside = GetSide();
 
+    //if launcher exists and is friendly, friendly fire is off, and damage is > 0 (not repairing), do no damage.
     if (launcher &&
         (!GetMyMission()->GetMissionParams()->bAllowFriendlyFire) &&
 		((pside == launcher->GetSide()) || IsideIGC::AlliedSides(pside,launcher->GetSide())) && // #ALLY - Imago fixed 7/8/09
@@ -1246,12 +1247,13 @@ DamageResult CshipIGC::ReceiveDamage(DamageTypeID            type,
         leakage = 0.0f;
         dr = c_drNoDamage;
 
+        //if launcher is repairing a friendly ship, add that the launcher's repair stat
 		if (launcher->GetObjectType() == OT_ship && (pside == launcher->GetSide() || IsideIGC::AlliedSides(pside, launcher->GetSide())))
 		{
 			IshipIGC * pIship = ((IshipIGC*)launcher);
             float   repairFraction = -amount * dtmArmor / maxHP;
             if (GetBaseHullType() && (GetBaseHullType()->GetCapabilities() & c_habmThreatToStation))
-                repairFraction *= 2.0f; //double points for nanning a bomber/htt
+                repairFraction *= 2.0f; //double points for nanning a bomber/htt 
 			pIship->AddRepair(repairFraction);
 			pIship->SetAchievementMask(c_achmNewRepair);
 		}
@@ -1263,12 +1265,13 @@ DamageResult CshipIGC::ReceiveDamage(DamageTypeID            type,
         if (launcher)
         {
             if (launcher->GetObjectType() == OT_ship)
-                amount *= ((IshipIGC*)launcher)->GetExperienceMultiplier();
+                amount *= ((IshipIGC*)launcher)->GetExperienceMultiplier(); //Student Note: This is kb multiplier. Also, repairing is not affected by kb
 
             if (m_damageTrack && (launcher->GetMission() == GetMyMission()))
                 m_damageTrack->ApplyDamage(timeCollision, launcher, amount);
         }
 
+        //Student Note: here is where shields take damage and where we would implement (maybe) shields not giving leakage (probably for a special shield or something)
         if (m_mountedOthers[ET_Shield])
         {
             Vector  deltaP = position2 - position1;

--- a/src/Igc/shipIGC.h
+++ b/src/Igc/shipIGC.h
@@ -1754,7 +1754,7 @@ class       CshipIGC : public TmodelIGC<IshipIGC>
                 assert (pship->GetSide() == pside);
                 assert (pship->GetAutoDonate() == NULL);
 
-                //Was anyone on my ide donating to me ... if so, they start donating to the new person
+                //Was anyone on my side donating to me ... if so, they start donating to the new person
                 for (ShipLinkIGC*   psl = pside->GetShips()->first();
                      (psl != NULL);
                      psl = psl->next())

--- a/src/WinTrek/artwork.h
+++ b/src/WinTrek/artwork.h
@@ -82,6 +82,7 @@
 #define AWF_FLIGHT_CURRENT_DIRECTION_ICON       "directionbmp"
 #define AWF_FLIGHT_CROSSHAIR_IN_ICON            "centerinbmp"
 #define AWF_FLIGHT_CROSSHAIR_OUT_ICON           "centeroutbmp"
+#define AWF_FLIGHT_EYE_ICON						"eyebmp" //Student 7/2/2022 Show friendly eyed ships
 
 #define AWF_HUD_BACKGROUND                      "hudbkgrndbmp"
 #define AWF_HUD_SPEED_INDICATOR                 "speedindicatorbmp"

--- a/src/WinTrek/cmdview.cpp
+++ b/src/WinTrek/cmdview.cpp
@@ -13,17 +13,20 @@
 float xMin, float yMin, 
                        float xMax, float yMax, 
 */
-CommandGeo::CommandGeo(float radius, float zGrid, int nSegments)
-:
-        m_vertices(
-            4 * (nSegments + 1),
-            4 * (nSegments + 1)
-        ),
-        m_indices(
-            4 * (nSegments + 1),
-            4 * (nSegments + 1)
-        ),
-        m_zGrid(zGrid)
+//Surface* top
+CommandGeo::CommandGeo(float radius, float zGrid, int nSegments) 
+    :
+    m_vertices(
+        4 * (nSegments + 1),
+        4 * (nSegments + 1)
+    ),
+    m_indices(
+        4 * (nSegments + 1),
+        4 * (nSegments + 1)
+    ),
+    m_zGrid(zGrid),
+    m_radius(radius)
+    //m_top(top)
 {
     int index = 0;
     float radius2 = radius * radius;
@@ -256,6 +259,27 @@ void CommandGeo::DrawShips(Context* pcontext)
         pcontext->DrawLines(vertices, indices);
 }
 
+//Student 7/18/2022 - indicate the original top of the sector, so it can be rotated and there still be a point of reference to discuss with teammates.
+void CommandGeo::DrawTop(Context* pcontext)
+{
+    TRef<IEngineFont> pfont = TrekResources::HugeBoldFont();
+
+    char* topString = "NORTH";
+    float xShiftStr = pfont->GetTextExtent(topString).X();
+    //float yShiftStr = pfont->GetHeight();
+    
+
+    //float yShiftArrow = m_top->GetSize().Y();
+    //float xShiftArrow = m_top->GetSize().X();
+
+    
+    Point offset(0, 3 * m_radius / 4);
+    //pcontext->DrawImage3D(m_top, s_colorNeutral, true, offset); //Something is going wrong with this image.
+    
+    offset.SetX(offset.X() - xShiftStr * 0.5f);
+
+    pcontext->DrawString(pfont, s_colorNeutral, offset, topString);
+}
 
 void CommandGeo::Render(Context* pcontext)
 {
@@ -267,6 +291,8 @@ void CommandGeo::Render(Context* pcontext)
 
     // draw the grid
     pcontext->DrawLines(m_vertices, m_indices);
+
+    DrawTop(pcontext);
 
     //Draw the drop line for the point in space (if there is one)
     {
@@ -287,6 +313,7 @@ const Color CommandGeo::s_colorGridMajor(0,0,128.0f/255.0f);
 const Color CommandGeo::s_colorDropLineUp(200.0f / 255.0f, 180.0f / 255.0f, 20.0f / 255.0f);
 const Color CommandGeo::s_colorDropLineDown(150.0f / 255.0f, 100.0f / 255.0f, 0.0f / 255.0f);
 const Color CommandGeo::s_colorFeet(0,0,128.0f/255.0f);
+const Color CommandGeo::s_colorNeutral(1.0f, 1.0f, 1.0f);
 
 const Color g_colorUp(75 / 255.0f, 124 / 255.0f, 88 / 255.0f);
 const Color g_colorDown(2 / 255.0f, 84 / 255.0f, 84 / 255.0f);

--- a/src/WinTrek/cmdview.h
+++ b/src/WinTrek/cmdview.h
@@ -62,11 +62,16 @@ private:
     TVector<WORD>     m_indices;
     TRef<IclusterIGC> m_pcluster;
     float             m_zGrid;
+    float             m_radius;
+
+    
+    //TRef<Surface>  m_top; //GetModeler()->LoadImage("toparrowbmp", true)->GetSurface();
 
     void DrawShips(Context* pcontext);
+    void DrawTop(Context* pcontext);
 
 public:
-    CommandGeo(float radius, float zGrid, int nSegments);
+    CommandGeo(float radius, float zGrid, int nSegments); //Surface* top
     void Render(Context* pcontext);
     void SetCluster(IclusterIGC* pcluster);
 


### PR DESCRIPTION
* minor grammar changes

* Added an option to change the shake from boosting.

* changed instances of boosterShake to boosterJiggle to align with previous code

* WIP, indicate whether friendly ship is spotted

* works on AI assets, need to work on icon positioning and on players (which the plan is for it to only work on players.

* Moved where we draw the eye, fixed not showing players.

* Final eye radar logic—only show on players on our team that are not ourselves.

* Working on adding indication for friendly ripcord numbers and changing how left side (cmd icon and eye icon currently is rendered) STATE: improper centering on multiple icons

* A bit more polish on ripcord/icons placing. Ripcord is still not centered when there are icons.

* Ripcord numbers look better. Added explanatory comments.

* Comments on future ideas/explanations

* testing auto-build for next-release.

* All friendly ships now show ripcord time.

* All friendly ships now show ripcord time.

* Fix seeing ripcord times for enemy players.

* Fix: Custom hud preference is now saved and loaded correctly
Add: Small text (WIP) to indicate "NORTH"

* WIP Load anti-aliasing from settings

* Now loads Anti-Aliasing and Vsync Preference Correctly. Transparent Objects string format improvement.